### PR TITLE
Ignore already inferred addresses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/OpenAddressesUK/mongoid_address_models.git
-  revision: b09f30205a93bc7531c781087c35a0a8b645875e
+  revision: d926cdb07f3a43fb697f20ea6c100d7d8813c072
   specs:
     mongoid_address_models (0.0.1)
       mongoid
@@ -56,7 +56,7 @@ GEM
       timers (~> 4.0.0)
     coderay (1.1.0)
     columnize (0.9.0)
-    connection_pool (2.1.1)
+    connection_pool (2.2.0)
     cucumber (1.3.19)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -71,12 +71,12 @@ GEM
     database_cleaner (1.3.0)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
-    elasticsearch (1.0.6)
-      elasticsearch-api (= 1.0.6)
-      elasticsearch-transport (= 1.0.6)
-    elasticsearch-api (1.0.6)
+    elasticsearch (1.0.8)
+      elasticsearch-api (= 1.0.7)
+      elasticsearch-transport (= 1.0.7)
+    elasticsearch-api (1.0.7)
       multi_json
-    elasticsearch-transport (1.0.6)
+    elasticsearch-transport (1.0.7)
       faraday
       multi_json
     erubis (2.7.0)
@@ -112,7 +112,6 @@ GEM
       moneta
       multi_json (>= 1.9.2)
       netrc
-    hike (1.2.3)
     hitimes (1.2.2)
     i18n (0.7.0)
     json (1.8.2)
@@ -206,18 +205,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
     shellany (0.0.1)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.6.0)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.0.3)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)

--- a/features/jess.feature
+++ b/features/jess.feature
@@ -340,6 +340,48 @@ Feature: Make sure it's plumbed in correctly
 ]
 """
 
+  Scenario: Inferrence with existing address as a source
+  Given the following addresses exist:
+  | paon  | street      | town     | postcode | source    |
+  | 7     | HIGH STREET | TESTTOWN | SW1A 1AA | url       |
+  | 1     | HIGH STREET | TESTTOWN | SW1A 1AA | url       |
+  | 11    | HIGH STREET | TESTTOWN | SW1A 1AA | inference |
+  And I send a request to infer from the address "1, HIGH STREET, TESTTOWN, SW1A 1AA"
+  Then the JSON response should contain:
+"""
+[
+{
+  "saon": null,
+  "paon": 3,
+  "street": "HIGH STREET",
+  "locality": null,
+  "town": "TESTTOWN",
+  "postcode": "SW1A 1AA"
+},
+{
+  "saon": null,
+  "paon": 5,
+  "street": "HIGH STREET",
+  "locality": null,
+  "town": "TESTTOWN",
+  "postcode": "SW1A 1AA"
+}
+]
+"""
+  And the JSON response should not contain:
+"""
+[
+{
+  "saon": null,
+  "paon": 9,
+  "street": "HIGH STREET",
+  "locality": null,
+  "town": "TESTTOWN",
+  "postcode": "SW1A 1AA"
+}
+]
+"""
+
   @timecop
   Scenario: Inferrence with existing address adds provenance
     Given it is currently "2015-01-01T12:00:00"

--- a/features/jess.feature
+++ b/features/jess.feature
@@ -340,7 +340,7 @@ Feature: Make sure it's plumbed in correctly
 ]
 """
 
-  Scenario: Inferrence with existing address as a source
+  Scenario: Inferrence with existing address as a source ignores inferred addresses
   Given the following addresses exist:
   | paon  | street      | town     | postcode | source    |
   | 7     | HIGH STREET | TESTTOWN | SW1A 1AA | url       |

--- a/features/jess.feature
+++ b/features/jess.feature
@@ -382,6 +382,19 @@ Feature: Make sure it's plumbed in correctly
 ]
 """
 
+  Scenario: Inferrence with existing inferred address as a source
+  Given the following addresses exist:
+  | paon | street      | town     | postcode | source    |
+  | 7    | HIGH STREET | TESTTOWN | SW1A 1AA | url       |
+  | 1    | HIGH STREET | TESTTOWN | SW1A 1AA | inference |
+  And I send a request to infer from the address "1, HIGH STREET, TESTTOWN, SW1A 1AA"
+  Then the response status should be "400"
+  And the JSON response should be:
+"""
+{
+  "error": "Sorry! We can't infer from inferred addresses"
+}
+"""
   @timecop
   Scenario: Inferrence with existing address adds provenance
     Given it is currently "2015-01-01T12:00:00"

--- a/features/step_definitions/address_steps.rb
+++ b/features/step_definitions/address_steps.rb
@@ -7,6 +7,7 @@ Given(/^the following addresses exist:$/) do |addresses|
                       locality: address[:locality].nil? ? nil : FactoryGirl.create(:locality, name: address[:locality]),
                       town: FactoryGirl.create(:town, name: address[:town]),
                       postcode: FactoryGirl.create(:postcode, name: address[:postcode]),
+                      source: address[:source].nil? ? "url" : address[:source],
                       provenance: {
                         activity: {
                           derived_from: [
@@ -23,13 +24,17 @@ Given(/^the following addresses exist:$/) do |addresses|
   end
 end
 
-Then /^the JSON response should contain:$/ do |json|
+Then /^the JSON response should ?(not)? contain:$/ do |match, json|
   expected = Regexp.escape(JSON.parse(json).to_s)
   actual = JSON.parse(last_response.body).to_s
 
   expected.gsub!("\\*", ".+")
 
-  actual.should match /#{expected}/
+  if match == "not"
+    actual.should_not match(/#{expected}/)
+  else
+    actual.should match(/#{expected}/)
+  end
 end
 
 Then(/^I send a request to infer from the address "(.*?)"$/) do |address|

--- a/lib/jess.rb
+++ b/lib/jess.rb
@@ -13,7 +13,15 @@ class Jess < Sinatra::Base
 
   post '/infer' do
     if params[:token]
-      source = address_hash(Address.find(params[:token]))
+      address = Address.find(params[:token])
+      if address.source == "inference"
+        status 400
+        return {
+          "error" => "Sorry! We can't infer from inferred addresses"
+        }.to_json
+      else
+        source = address_hash(address)
+      end
     else
       source = JSON.parse(request.body.read)
       ["street", "locality", "town"].each { |s| source[s].upcase! if source[s].class == String }

--- a/lib/jess.rb
+++ b/lib/jess.rb
@@ -18,7 +18,7 @@ class Jess < Sinatra::Base
       source = JSON.parse(request.body.read)
       ["street", "locality", "town"].each { |s| source[s].upcase! if source[s].class == String }
     end
-    addresses = Address.where("street.name" => source["street"], "postcode.name" => source["postcode"]).map { |a| address_hash(a) }
+    addresses = Address.where("street.name" => source["street"], "postcode.name" => source["postcode"], :source.ne => "inference").map { |a| address_hash(a) }
     addresses << source
     # Remove any addresses that start with 0 or are excessively large or are non-numeric
     addresses.delete_if { |a| a["paon"] =~ /^0.+$/ || a["paon"].to_i > 2000 || a["paon"] =~ /[^0-9]/ }
@@ -36,7 +36,7 @@ class Jess < Sinatra::Base
       state = paon_state(addresses)
 
       existing = addresses.map {|x| x.except("provenance")}.reject { |a| a == source }
-      
+
       min = addresses.first["paon"] + (state == "mixed" ? 1 : 2)
       max = addresses.last["paon"] - (state == "mixed" ? 1 : 2)
 


### PR DESCRIPTION
Now we have inferred addresses in the live DB, we need to ignore these when inferring addresses further
